### PR TITLE
Prevent gulp crashing of buildDest is empty

### DIFF
--- a/gulp-tasks/clean.js
+++ b/gulp-tasks/clean.js
@@ -4,6 +4,9 @@ var clean   = require('gulp-clean');
 
 // cleanup the build output
 gulp.task('clean-build', function () {
-  return gulp.src(project.buildDest, {read: false})
+  return gulp.src(project.buildDest, {
+    read: false,
+  	allowEmpty: true
+  })
     .pipe(clean());
 });


### PR DESCRIPTION
If you run this on a fresh project it errors because it expects to find the buildDest. This sometimes causes issues where you run build:clean twice in quick succession. The first will delete the build directory, but the second crashes because it can't find it.