### PR TITLE
fix(footer.njk): improve spelling

### DIFF
--- a/src/site/_includes/footer.njk
+++ b/src/site/_includes/footer.njk
@@ -1,6 +1,6 @@
 <footer>
 <p>
-  The code is maintained by <a href="https://twitter.com/philhawksworth">Phil Hawksworth</a> for his own reference and as a quick start for some of his projetcs, but take it if it is useful to you too. Find the repo on <a href="{{ pkg.repository.url }}">Github</a>.
+  The code is maintained by <a href="https://twitter.com/philhawksworth">Phil Hawksworth</a> for his own reference and as a quick start for some of his projects, but take it if it is useful for you too. Find the repo on <a href="{{ pkg.repository.url }}">GitHub</a>.
 </p>
 <p>
   This page was generated on {{ site.buildTime | dateDisplay('LLL d, yyyy - HH:mm') }}


### PR DESCRIPTION
- Improve spelling
  - Change `Github` to `GitHub` to match with the official brand name
  - Change `projetcs` to `projects`
  - Change `useful to you` to `useful for you`