### PR TITLE
Use async fs.readFile() rather than sync one

### DIFF
--- a/src/site/css/styles.11ty.js
+++ b/src/site/css/styles.11ty.js
@@ -1,6 +1,9 @@
 const fs = require('fs');
 const path = require('path');
+const { promisify } = require('util');
 const postcss = require('postcss');
+
+const asyncReadFile = promisify(fs.readFile);
 
 // the file name as an entry point for postcss compilation
 // also used to define the output filename in our output /css folder.
@@ -12,7 +15,7 @@ module.exports = class {
     return {
       permalink: `css/${fileName}`,
       rawFilepath,
-      rawCss: await fs.readFileSync(rawFilepath)
+      rawCss: await asyncReadFile(rawFilepath)
     };
   };
 


### PR DESCRIPTION
Noticed that the current code in `styles.11ty.js` is `await`:ing a synchronous method call when it would be better for it to await an async one.

So here is a change that makes it use the async one.