### PR TITLE
Exclude CSS from 11ty collections

### DIFF
--- a/src/site/css/styles.11ty.js
+++ b/src/site/css/styles.11ty.js
@@ -11,6 +11,7 @@ module.exports = class {
     const rawFilepath = path.join(__dirname, `../_includes/postcss/${fileName}`);
     return {
       permalink: `css/${fileName}`,
+      eleventyExcludeFromCollections: true,
       rawFilepath,
       rawCss: await fs.readFileSync(rawFilepath)
     };


### PR DESCRIPTION
Great idea using a JS template as PostCSS pipeline!

Folks probably don't want their css file in their 11ty collections data. This PR excludes the styles.11ty.js template.