### PR TITLE
Typo in README.md line52

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ npm install
 npm run seed
 
 # It will then be available locally for building with
-npom start
+npm start
 ```
 
 ## Add some Netlify helpers


### PR DESCRIPTION
There is a typo in the README.md, line 52

npom start should be "npm start"